### PR TITLE
ci: upgrade Fedora 35 to Fedora 36 in GitLab CI job for Fedora

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,9 +49,9 @@ docker_image_fedora:
     - docker:20-dind
   script:
     - cd ci/
-    - docker build -t $CI_REGISTRY/striezel/gimli/fedora:fc35 . -f Dockerfile_fedora
+    - docker build -t $CI_REGISTRY/striezel/gimli/fedora:fc36 . -f Dockerfile_fedora
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker push $CI_REGISTRY/striezel/gimli/fedora:fc35
+    - docker push $CI_REGISTRY/striezel/gimli/fedora:fc36
     - docker logout $CI_REGISTRY
   # Only build new image when the Dockerfile or the GitLab CI configuration
   # changes.
@@ -61,7 +61,7 @@ docker_image_fedora:
       - .gitlab-ci.yml
 
 fedora:
-  image: registry.gitlab.com/striezel/gimli/fedora:fc35
+  image: registry.gitlab.com/striezel/gimli/fedora:fc36
   stage: test
   before_script:
     - yum update -y

--- a/ci/Dockerfile_fedora
+++ b/ci/Dockerfile_fedora
@@ -1,5 +1,5 @@
 # This Dockerfile builds the image used during the fedora build job on GitLab.
-FROM fedora:35
+FROM fedora:36
 LABEL maintainer="Dirk Stolle <striezel-dev@web.de>"
 # Always update any existing packages first.
 RUN yum update -y


### PR DESCRIPTION
Fedora 36 has been released almost three months ago, and the
previously used Fedora 35 will reach its end of life in ca. three
months. So let's stay ahead of that.